### PR TITLE
add Atomist webhook to Circle CI 1.0

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -14,3 +14,19 @@ editor:
   parameters:
     - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/circle"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddCircleWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.43"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "master"
+    sha: "a27f45e"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/circle"
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
   timezone:
     America/Los_Angeles
-
+notify:
+  webhooks:
+  - url: 'https://webhook.atomist.com/atomist/circle'


### PR DESCRIPTION
Created by Atomist Editor `AddCircleWebhookEditor`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170816122823"
editor:
  name: "AddCircleWebhookEditor"
  group: "atomist"
  artifact: "enrollment-rugs"
  version: "0.3.43"
  origin:
    repo: "git@github.com:atomisthq/enrollment-rugs.git"
    branch: "master"
    sha: "a27f45e"
  parameters:
    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/circle"

```